### PR TITLE
Add option to pass in a query and serializer for adding disallowed urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-[![NPM version](https://img.shields.io/npm/v/gatsby-plugin-robots-txt.svg)](https://www.npmjs.org/package/gatsby-plugin-robots-txt)
-[![Travis build status](https://travis-ci.org/mdreizin/gatsby-plugin-robots-txt.svg?branch=master)](https://travis-ci.org/mdreizin/gatsby-plugin-robots-txt)
-[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/ow75w9pjm7kf3wps/branch/master?svg=true)](https://ci.appveyor.com/project/mdreizin/gatsby-plugin-robots-txt/branch/master)
-[![Maintainability](https://api.codeclimate.com/v1/badges/03b12a836565bd04674c/maintainability)](https://codeclimate.com/github/mdreizin/gatsby-plugin-robots-txt/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/03b12a836565bd04674c/test_coverage)](https://codeclimate.com/github/mdreizin/gatsby-plugin-robots-txt/test_coverage)
-[![Dependency Status](https://img.shields.io/david/mdreizin/gatsby-plugin-robots-txt.svg)](https://david-dm.org/mdreizin/gatsby-plugin-robots-txt)
-[![Development Dependency Status](https://img.shields.io/david/dev/mdreizin/gatsby-plugin-robots-txt.svg)](https://david-dm.org/mdreizin/gatsby-plugin-robots-txt#info=devDependencies)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt?ref=badge_shield)
+# @trussle/gatsby-plugin-robots-txt
+
+Based on `mdreizin/gatsby-plugin-robots-txt`. Added options to fetch data from a GraphQL query and append it to the list of disallowed URLs.
 
 # gatsby-plugin-robots-txt
 
@@ -13,11 +8,7 @@
 
 ## Install
 
-`yarn add gatsby-plugin-robots-txt`
-
-or
-
-`npm install --save gatsby-plugin-robots-txt`
+`npm install --save @trussle/gatsby-plugin-robots-txt`
 
 ## How To Use
 
@@ -28,7 +19,7 @@ module.exports = {
   siteMetadata: {
     siteUrl: 'https://www.example.com'
   },
-  plugins: ['gatsby-plugin-robots-txt']
+  plugins: ['@trussle/gatsby-plugin-robots-txt']
 };
 ```
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -59,7 +59,7 @@ export async function onPostBuild({ graphql }, pluginOptions) {
 
   if (
     !Object.prototype.hasOwnProperty.call(mergedOptions, 'host') ||
-    !Object.prototype.hasOwnProperty.call(mergedOptions,'sitemap')
+    !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
   ) {
     const {
       site: {
@@ -71,7 +71,29 @@ export async function onPostBuild({ graphql }, pluginOptions) {
     mergedOptions.sitemap = url.resolve(siteUrl, 'sitemap.xml');
   }
 
-  const { policy, sitemap, host, output, configFile } = mergedOptions;
+  const {
+    policy,
+    sitemap,
+    host,
+    output,
+    configFile,
+    disallowQuery,
+    disallowSerializer
+  } = mergedOptions;
+
+  if (disallowQuery && disallowSerializer) {
+    const disallowUrls = disallowSerializer(
+      await runQuery(graphql, disallowQuery)
+    );
+
+    policy.forEach(p => {
+      if (Array.isArray(p.disallow)) {
+        p.disallow = p.disallow.concat(disallowUrls);
+      } else {
+        p.disallow = disallowUrls;
+      }
+    });
+  }
 
   const content = await robotsTxt({
     policy,

--- a/test/__snapshots__/gatsby-node.test.js.snap
+++ b/test/__snapshots__/gatsby-node.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`onPostBuild should add disallowed urls fetched from GraphQL query to \`robots.txt\` 1`] = `
+"User-agent: *
+Disallow: /foo
+Disallow: /bar
+
+User-agent: Googlebot
+Disallow: /bar
+Sitemap: https://www.test.com/sitemap.xml
+Host: https://www.test.com
+"
+`;
+
 exports[`onPostBuild should generate \`robots.txt\` using \`env\` options 1`] = `
 "User-agent: *
 Disallow: /

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -154,4 +154,32 @@ describe('onPostBuild', () => {
 
     expect(readContent(output)).toMatchSnapshot();
   });
+
+  it('should add disallowed urls fetched from GraphQL query to `robots.txt`', async () => {
+    const output = './robots-graphql-disallow-additions.txt';
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({
+            data: {
+              myPages: [{
+                url: "/bar"
+              }]
+            }
+          });
+        }
+      },
+      {
+        host: 'https://www.test.com',
+        sitemap: 'https://www.test.com/sitemap.xml',
+        policy: [{ userAgent: '*', disallow: ['/foo'] }, { userAgent: 'Googlebot' }],
+        output,
+        disallowQuery: `{ myPages: { url } }`,
+        disallowSerializer: ({ myPages }) => myPages.map(p => p.url)
+      }
+    );
+
+    expect(readContent(output)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
The plugin `gatsby-plugin-robots-txt` only allowed us to write a fixed set of URLs in the config. I've modified it to take a two options
`disallowQuery` and `disallowSerializer`

- `disallowQuery` is the GraphQL query for fetching the data
- `disallowSerializer` is a function to serialize the returned data into a list of URLs
- The result from `disallowSerializer` is appended to the list of disallowed URLs in the robots.txt
